### PR TITLE
(fix) option to force using internel forward-like

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 option(PGBAR_INSTALL "Enable install target" ${PGBAR_IN_TOP_LEVEL})
 option(PGBAR_PACKAGE "Enable packaging support" ${PGBAR_IN_TOP_LEVEL})
 option(PGBAR_BUILD_DEMO "Build demo programs from demo/ directory using Makefile" OFF)
+option(PGBAR_USE_INTERNAL_FORWARD_LIKE "Use internal implementation of std::forward_like (for clang with libstdc++)" OFF)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -32,6 +33,10 @@ set_target_properties(pgbar PROPERTIES CXX_EXTENSIONS OFF)
 target_include_directories(pgbar INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+if(PGBAR_USE_INTERNAL_FORWARD_LIKE)
+  target_compile_definitions(pgbar INTERFACE "NO_FORWARD_LIKE")
+endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14")
   set_property(TARGET pgbar PROPERTY LICENSE "MIT")

--- a/include/pgbar/details/utils/Backport.hpp
+++ b/include/pgbar/details/utils/Backport.hpp
@@ -185,7 +185,7 @@ namespace pgbar {
       }
 #endif
 
-#if PGBAR__CXX23
+#if PGBAR__CXX23 && !defined( NO_FORWARD_LIKE )
       template<typename E>
       PGBAR__NODISCARD PGBAR__FORCEINLINE PGBAR__CNSTEVAL auto as_val( E enum_val ) noexcept
       {
@@ -199,8 +199,8 @@ namespace pgbar {
       }
 #else
       template<typename E>
-      PGBAR__NODISCARD PGBAR__FORCEINLINE PGBAR__CNSTEVAL typename std::underlying_type<E>::type as_val(
-        E enum_val ) noexcept
+      PGBAR__NODISCARD PGBAR__FORCEINLINE PGBAR__CNSTEVAL
+        typename std::underlying_type<E>::type as_val( E enum_val ) noexcept
       {
         return static_cast<typename std::underlying_type<E>::type>( enum_val );
       }


### PR DESCRIPTION
## Bug Description

`std::forward_like` is not available for clang with libstdc++, need to force using internal implementation of `forward_like`.

[[Clang] libstdc++’s std::forward_like doesn’t compile](<https://github.com/llvm/llvm-project/issues/101614>)

### Buggy Environment:

System: Ubuntu
Standard: c++23

- clang-x86_64-pc-linux-gnu 21.1.5
- clang-x86_64-pc-linux-gnu 20.1.8

### Passing Environment

- gcc 13.3.0

## Solution

Add an compile definition to force using internal implementation of `std::forward_like`