### PR TITLE
Fixes: #5 Multiple definition of uncaught_exceptions

### DIFF
--- a/include/pgbar/details/utils/Backport.hpp
+++ b/include/pgbar/details/utils/Backport.hpp
@@ -36,7 +36,7 @@ namespace pgbar {
       }
 #endif
 
-      int uncaught_exceptions() noexcept
+      inline int uncaught_exceptions() noexcept
       {
 #ifdef __cpp_lib_uncaught_exceptions
         return std::uncaught_exceptions();


### PR DESCRIPTION
Changes `uncaught_exceptions` to be inline which seems to fix the multiple definition errors